### PR TITLE
Loosen up version requirements for jason

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule SafeCode.MixProject do
     [
       {:mix_test_watch, "~> 1.1.0", env: :dev, runtime: false},
       {:phoenix_live_view, "~> 0.17.5"},
-      {:jason, "~> 1.3.0"},
+      {:jason, "~> 1.3"},
       {:credo, "~> 1.6.1", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
       # {:dep_from_hexpm, "~> 0.3.0"},


### PR DESCRIPTION
I tried to install beacon cms to new phoenix application. Fresh elixir app with phoenix pulls latest jason v1.4.0 which is "not supported" by beacon because of this =)