### PR TITLE
Downgrade Elixir version to 1.12

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule SafeCode.MixProject do
       app: :safe_code,
       description: "Validate if code is safe to load and run",
       version: "0.2.2",
-      elixir: "~> 1.13",
+      elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       source_url: "https://github.com/TheFirstAvenger/safe_code",
       deps: deps(),


### PR DESCRIPTION
@TheFirstAvenger can we make this change? Beacon is using 1.12 following Phoenix LiveView:

https://github.com/BeaconCMS/beacon/blob/main/mix.exs#L10 https://github.com/phoenixframework/phoenix_live_view/blob/main/mix.exs#L10