### PR TITLE
Additional validate_heex func

### DIFF
--- a/lib/safe_code/validator.ex
+++ b/lib/safe_code/validator.ex
@@ -25,7 +25,7 @@ defmodule SafeCode.Validator do
     |> validate_quoted(opts)
   end
 
-  @spec validate_heex(binary, keyword) :: {:ok, ast :: Macro.t()} | {:error, %Phoenix.LiveView.HTMLTokenizer.ParseError{}}
+  @spec validate_heex(binary, keyword) :: {:ok, ast :: Macro.t()} | {:error, Exception.t()}
   def validate_heex(heex, opts \\ []) when is_binary(heex) do
     quoted =
       heex
@@ -34,7 +34,7 @@ defmodule SafeCode.Validator do
 
     {:ok, quoted}
   rescue
-    error in Phoenix.LiveView.HTMLTokenizer.ParseError -> {:error, error}
+    error -> {:error, error}
   end
 
   def validate_heex!(heex, opts \\ []) when is_binary(heex) do

--- a/lib/safe_code/validator.ex
+++ b/lib/safe_code/validator.ex
@@ -25,6 +25,18 @@ defmodule SafeCode.Validator do
     |> validate_quoted(opts)
   end
 
+  @spec validate_heex(binary, keyword) :: {:ok, ast :: Macro.t()} | {:error, %Phoenix.LiveView.HTMLTokenizer.ParseError{}}
+  def validate_heex(heex, opts \\ []) when is_binary(heex) do
+    quoted =
+      heex
+      |> HeexParser.parse_template()
+      |> validate_quoted(include_phoenix(opts))
+
+    {:ok, quoted}
+  rescue
+    error in Phoenix.LiveView.HTMLTokenizer.ParseError -> {:error, error}
+  end
+
   def validate_heex!(heex, opts \\ []) when is_binary(heex) do
     heex
     |> HeexParser.parse_template()

--- a/test/safe_code/validator_test.exs
+++ b/test/safe_code/validator_test.exs
@@ -61,14 +61,13 @@ defmodule SafeCode.ValidatorTest do
       assert error.description == "end of template reached without closing tag for <div>"
     end
 
-    test "raises on problem function" do
+    test "return an error tuple on problem function" do
       str = """
       <%= System.cmd("touch", ["foo"]) %>
       """
 
-      assert_raise InvalidNode, "System . :cmd\n\nast:\n{:., [line: 1], [{:__aliases__, [line: 1], [:System]}, :cmd]}", fn ->
-        Validator.validate_heex(str)
-      end
+      assert {:error, %InvalidNode{} = error} = Validator.validate_heex(str)
+      assert error.message == "System . :cmd\n\nast:\n{:., [line: 1], [{:__aliases__, [line: 1], [:System]}, :cmd]}"
     end
   end
 

--- a/test/safe_code/validator_test.exs
+++ b/test/safe_code/validator_test.exs
@@ -38,6 +38,46 @@ defmodule SafeCode.ValidatorTest do
       hello <%= 1 + 1 %> how <%= 2+2 %> are you
       """
 
+      assert {:ok, _quoted} = Validator.validate_heex(heex)
+    end
+
+    test "for loop" do
+      heex = """
+      <%= for foo <- bar do %>
+        <%= foo %>
+      <% end %>
+      """
+
+      assert {:ok, _quoted} = Validator.validate_heex(heex)
+    end
+
+    test "return the error tuple when invalid template" do
+      heex = """
+      <div>
+        hello <%= 1 + 1 %> how <%= 2+2 %> are you
+      """
+
+      assert {:error, %Phoenix.LiveView.HTMLTokenizer.ParseError{} = error} = Validator.validate_heex(heex)
+      assert error.description == "end of template reached without closing tag for <div>"
+    end
+
+    test "raises on problem function" do
+      str = """
+      <%= System.cmd("touch", ["foo"]) %>
+      """
+
+      assert_raise InvalidNode, "System . :cmd\n\nast:\n{:., [line: 1], [{:__aliases__, [line: 1], [:System]}, :cmd]}", fn ->
+        Validator.validate_heex(str)
+      end
+    end
+  end
+
+  describe "validate_heex!/1" do
+    test "basic" do
+      heex = """
+      hello <%= 1 + 1 %> how <%= 2+2 %> are you
+      """
+
       assert Validator.validate_heex!(heex)
     end
 


### PR DESCRIPTION
Add an additional `validate_heex` func that doesn't throw exceptions if the template is invalid.

I discussed it with Leandro and we thought it would be worth having a version of this function that doesn't throw exception when the template is invalid. We believe that it would be useful in some cases in Beacon, for example, right now I'm solving  the issue https://github.com/BeaconCMS/beacon/issues/74 and this function would be very handy to add the template error into an invalid changeset.

